### PR TITLE
Better object handling

### DIFF
--- a/codec/number.js
+++ b/codec/number.js
@@ -7,28 +7,28 @@
 // Then negative numbers' mantissa and exponent are flipped (nines' complement)
 
 exports.encode = function (number) {
-    if (isNaN(number)) { return "NaN"; }
-    if (number === 0) { return "PE  0M0"; }
-    if (number === Infinity) { return "PF"; }
-    if (number === -Infinity) { return "ND"; }
+    if (isNaN(number)) { return "DaN"; }
+    if (number === 0) { return "FE  0M0"; }
+    if (number === Infinity) { return "FF"; }
+    if (number === -Infinity) { return "DD"; }
 
     var splitScientificNotation = number.toExponential().split('e');
     var exponent = Number(splitScientificNotation[1]) + 500;
     var mantissa = splitScientificNotation[0] + (splitScientificNotation[0].indexOf('.') === -1 ? '.' : '') + '0'.repeat(20);
     var encoded = 'E' + padStart(String(exponent), 3) + 'M' + String(mantissa);
     if (number > 0) {
-        return 'P' + encoded;
+        return 'F' + encoded;
     } else {
-        return 'N' + flip(encoded);
+        return 'D' + flip(encoded);
     }
 }
 
 exports.decode = function (encoded) {
-    if (encoded === 'NaN') { return NaN; }
-    if (encoded === 'PF') { return Infinity; }
-    if (encoded === 'ND') { return -Infinity; }
+    if (encoded === 'DaN') { return NaN; }
+    if (encoded === 'FF') { return Infinity; }
+    if (encoded === 'DD') { return -Infinity; }
 
-    var isNegative = encoded[0] === 'N';
+    var isNegative = encoded[0] === 'D';
     var splitEncoded = (isNegative ? flip(encoded) : encoded).slice(2).split('M');
     return Number((isNegative ? '-':'') + splitEncoded[1] + 'e' + String(Number(splitEncoded[0])-500));
 }

--- a/codec/object.js
+++ b/codec/object.js
@@ -1,0 +1,36 @@
+exports.factory = function (codec) {
+    return {
+        encode: function (array) {
+            if (array === null) { return 'A'; }
+            if (!Array.isArray(array)) { throw new Error('can only encode arrays'); }
+            return 'K' + array.map(function (item) {
+                return escape(codec.encode(item))
+            }).join('!');
+        },
+        decode: function (encoded) {
+            if (encoded === 'A') { return null; }
+            if (encoded === 'K') { return []; }
+            var buffer = "";
+            var array = [];
+            for (var i = 1; i < encoded.length; i++) {
+                var char = encoded[i];
+                if (char === '!' && encoded[i-1] !== '\\') {
+                    array.push(codec.decode(unescape(buffer)))
+                    buffer = '';
+                } else {
+                    buffer += char;
+                }
+            }
+            array.push(codec.decode(unescape(buffer)))
+            return array;
+        }
+    }
+}
+
+function escape (string) {
+    return string.replace(/!/g, '\\!')
+}
+
+function unescape (string) {
+    return string.replace(/\\!/g, '!')
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "bytewise": "^1.1.0",
     "check-ecmascript-version-compatibility": "^0.1.1",
+    "deep-equal": "^1.0.1",
     "glob": "^7.1.2",
     "tape": "^4.8.0",
     "typewiselite": "^1.0.0"

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -1,0 +1,52 @@
+var tape = require('tape')
+var codec = require('../codec/object.js').factory(require('../index.js'));
+var same = require('deep-equal');
+var bytewise = require('bytewise').encode;
+var encode = codec.encode;
+var decode = codec.decode;
+
+var words = ['foo', 'bar', 'hello!world', 'OSfail!Shard!A']
+
+var randArray = function (size) {
+    var array = [];
+    for (var i = 0; i < Math.ceil(Math.random() * size); i++) {
+        if (Math.random() > 0.5) { array.push(Math.random() > 0.5 ? true : false); }
+        if (Math.random() > 0.5) { array.push(Math.random() > 0.5 ? undefined : null); }
+        if (Math.random() > 0.5) { array.push((Math.random() - 0.5) * 4); }
+        if (Math.random() > 0.5) { array.push(words[Math.floor(Math.random() * words.length)]); }
+        if (Math.random() > 0.5) { array.push(randArray(size-1)); }
+    }
+    return array;
+}
+
+tape("Object: 1000 random array", function (t) {
+    var i;
+    for (i = 0; i < 1000; i++) {
+        var array1 = randArray(3);
+        var array2 = randArray(3);
+        if (!same(decode(encode(array1)), array1)) {
+            t.equals(decode(encode(array1)), array1, 'decode(encode(' + array1 + ')) !== ' + array1);
+            break;
+        }
+        if (!same(decode(encode(array2)), array2)) {
+            t.equals(decode(encode(array2)), array2, 'decode(encode(' + array2 + ')) !== ' + array2);
+            break;
+        }
+        if (bytewise(array1) < bytewise(array2) && encode(array1) >= encode(array2)) {
+            t.fail('encode(' + array1 + ') >= encode(' + array2 + ')');
+            break;
+        }
+        if (bytewise(array1) > bytewise(array2) && encode(array1) <= encode(array2)) {
+            t.fail('encode(' + array1 + ') >= encode(' + array2 + ')');
+            break;
+        }
+        if (bytewise(array1) === bytewise(array2) && encode(array1) === encode(array2)) {
+            t.fail('encode(' + array1 + ') >= encode(' + array2 + ')');
+            break;
+        }
+    }
+    if (i === 1000) {
+        t.pass('All random array validated')
+    }
+    t.end();
+});


### PR DESCRIPTION
Array are handled the same way as before. A type tag, and all items encoded and concatenated with a separator `!`.
Nested arrays are handled by escaping the item separator `!` with `\`

To have arrays order the same as with bytewise, order among types (null, boolean, string, array, etc...) should be the same. I took the liberty to change some of the type tags. The ease of use for some types ('A' for arrays, 'S' for string) is lost, but they now order the same as with bytewise.
I added a different type tag for `null` to differentiate it from an empty array `[]`

I had to code this codec as a factory to avoid circular dependecy between `index.js` and `codec/object.js` and still inject the general purpose `encode`/`decode` functions

This should fix #2