### PR TITLE
failing testcase for string ending in slash

### DIFF
--- a/test/object.test.js
+++ b/test/object.test.js
@@ -50,3 +50,13 @@ tape("Object: 1000 random array", function (t) {
     }
     t.end();
 });
+
+tape('edge cases', function (t) {
+  var examples = [[[[]]], ['hello\\', 'world'], ['hello!', 'world!']]
+  examples.forEach(function (a) {
+    t.deepEqual(decode(encode(a)), a)
+  })
+  t.deepEqual(decode(encode(examples)), examples)
+  t.end()
+})
+


### PR DESCRIPTION
@PaulBlanche when a string inside an array ends in '\' it doesn't decode properly

```
    expected: [ 'hello\\', 'world' ]
    actual:   [ 'hello!Jworld' ]
```

need to escape the escape which means [the escape logic](https://github.com/dominictarr/charwise/blob/master/codec/object.js#L20) can't just check wether the previous character is `\`, instead it needs to set a boolean on whether it's in escape mode when going forwards... this might effect ordering...