### PR TITLE
Fix/escaping

### DIFF
--- a/codec/object.js
+++ b/codec/object.js
@@ -17,7 +17,7 @@ exports.factory = function (codec) {
             var array = [];
             for (var i = 1; i < encoded.length; i++) {
                 var char = encoded[i];
-                if (char === '!' && encoded[i-1] !== '\\') {
+                if (char === '!') {
                     array.push(codec.decode(unescape(buffer)))
                     buffer = '';
                 } else {
@@ -31,11 +31,33 @@ exports.factory = function (codec) {
 }
 
 function escape (string) {
-    return string.replace(/!/g, '\\!')
+    var l = string.length;
+    var buffer = '';
+    for (var i = 0; i < l; i++) {
+        if (string[i] === '!') {
+            buffer += '??';
+        } else if (string[i] === '?') {
+            buffer += '?@';
+        } else {
+            buffer += string[i];
+        }
+    }
+    return buffer;
 }
 
 function unescape (string) {
-    return string.replace(/\\!/g, '!')
+    var l = string.length;
+    var buffer = '';
+    for (var i = 0; i < l; i++) {
+        if (string[i] === '?' && string[i+1] === '?') {
+            buffer += '!';
+            i++;
+        } else if (string[i] === '?' && string[i+1] === '@') {
+            buffer += '?';
+            i++;
+        } else {
+            buffer += string[i];
+        }
+    }
+    return buffer;
 }
-
-

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -52,11 +52,16 @@ tape("Object: 1000 random array", function (t) {
 });
 
 tape('edge cases', function (t) {
-  var examples = [[[[]]], ['hello\\', 'world'], ['hello!', 'world!']]
+  var examples = [
+      [[[]]],
+      ['hello\\', 'world'],
+      ['hello!', 'world!'],
+      ['hello?@!', 'world!'],
+      ['hello@?@!', 'world!']
+  ]
   examples.forEach(function (a) {
     t.deepEqual(decode(encode(a)), a)
   })
   t.deepEqual(decode(encode(examples)), examples)
   t.end()
 })
-

--- a/test/object.test.js
+++ b/test/object.test.js
@@ -50,3 +50,13 @@ tape("Object: 1000 random array", function (t) {
     }
     t.end();
 });
+
+tape('edge cases', function (t) {
+  var examples = [[[[]]], ['hello\\', 'world'], ['hello!', 'world!']]
+  examples.forEach(function (a) {
+    t.deepEqual(decode(encode(a)), a)
+  })
+  t.deepEqual(decode(encode(examples)), examples)
+  t.end()
+})
+


### PR DESCRIPTION
Should fix escaping problem with nested arrays :
* Array separator `!` is escaped as `??`
* Escaping symbol `?` is escaped as `?@`
That way, when a `!` is met, we can be sure it is an array seperator for
the current "level" of nested array.