### PR TITLE
Shorter encoding for numbers (breaking change)

### DIFF
--- a/codec/number.js
+++ b/codec/number.js
@@ -16,7 +16,7 @@ exports.encode = function (number) {
 
     var splitScientificNotation = number.toExponential().split('e');
     var exponent = Number(splitScientificNotation[1]) + 500;
-    var mantissa = splitScientificNotation[0] + (splitScientificNotation[0].indexOf('.') === -1 ? '.' : '')//+ '0'.repeat(20);
+    var mantissa = splitScientificNotation[0]
     var encoded = 'E' + padStart(String(exponent), 3) + 'M' + String(mantissa) + (number > 0 ? '' : END)
     if (number > 0) {
         return 'F' + encoded;
@@ -51,5 +51,4 @@ function flip(number) {
 function padStart (str, count) {
   return (' ').repeat(count - str.length).substr(0,count) + str;
 };
-
 

--- a/codec/number.js
+++ b/codec/number.js
@@ -14,8 +14,8 @@ exports.encode = function (number) {
 
     var splitScientificNotation = number.toExponential().split('e');
     var exponent = Number(splitScientificNotation[1]) + 500;
-    var mantissa = splitScientificNotation[0] + (splitScientificNotation[0].indexOf('.') === -1 ? '.' : '') + '0'.repeat(20);
-    var encoded = 'E' + padStart(String(exponent), 3) + 'M' + String(mantissa);
+    var mantissa = splitScientificNotation[0] + (splitScientificNotation[0].indexOf('.') === -1 ? '.' : '')//+ '0'.repeat(20);
+    var encoded = 'E' + padStart(String(exponent), 3) + 'M' + String(mantissa) + (number > 0 ? '' : 'a')
     if (number > 0) {
         return 'F' + encoded;
     } else {
@@ -30,7 +30,7 @@ exports.decode = function (encoded) {
 
     var isNegative = encoded[0] === 'D';
     var splitEncoded = (isNegative ? flip(encoded) : encoded).slice(2).split('M');
-    return Number((isNegative ? '-':'') + splitEncoded[1] + 'e' + String(Number(splitEncoded[0])-500));
+    return Number((isNegative ? '-':'') + splitEncoded[1].replace('a','') + 'e' + String(Number(splitEncoded[0])-500));
 }
 
 function flip(number) {
@@ -49,3 +49,5 @@ function flip(number) {
 function padStart (str, count) {
   return (' ').repeat(count - str.length).substr(0,count) + str;
 };
+
+

--- a/codec/number.js
+++ b/codec/number.js
@@ -6,6 +6,8 @@
 // We endpad mantissa with enough zero to exceed mantissa precision.
 // Then negative numbers' mantissa and exponent are flipped (nines' complement)
 
+var END = '_'
+
 exports.encode = function (number) {
     if (isNaN(number)) { return "DaN"; }
     if (number === 0) { return "FE  0M0"; }
@@ -15,7 +17,7 @@ exports.encode = function (number) {
     var splitScientificNotation = number.toExponential().split('e');
     var exponent = Number(splitScientificNotation[1]) + 500;
     var mantissa = splitScientificNotation[0] + (splitScientificNotation[0].indexOf('.') === -1 ? '.' : '')//+ '0'.repeat(20);
-    var encoded = 'E' + padStart(String(exponent), 3) + 'M' + String(mantissa) + (number > 0 ? '' : 'a')
+    var encoded = 'E' + padStart(String(exponent), 3) + 'M' + String(mantissa) + (number > 0 ? '' : END)
     if (number > 0) {
         return 'F' + encoded;
     } else {
@@ -30,7 +32,7 @@ exports.decode = function (encoded) {
 
     var isNegative = encoded[0] === 'D';
     var splitEncoded = (isNegative ? flip(encoded) : encoded).slice(2).split('M');
-    return Number((isNegative ? '-':'') + splitEncoded[1].replace('a','') + 'e' + String(Number(splitEncoded[0])-500));
+    return Number((isNegative ? '-':'') + splitEncoded[1].replace(END,'') + 'e' + String(Number(splitEncoded[0])-500));
 }
 
 function flip(number) {

--- a/test/bench.js
+++ b/test/bench.js
@@ -17,7 +17,7 @@ var randArray = function (opt, depth) {
         if (opt.depth != 0 && Math.random() < Math.max(0, opt.depth-depth)/opt.depth) {
             array.push(randArray(opt, depth + 1));
         } else {
-            var dice = Math.floor(Math.random() * 5)
+            var dice = Math.floor(Math.random() * 6)
             if(dice === 0) {
                 array.push(randString())
             }
@@ -32,6 +32,9 @@ var randArray = function (opt, depth) {
             }
             if(dice === 4) {
                 array.push((Math.random()*2 - 1)*1e10);
+            }
+            if(dice === 5) {
+                array.push(~~(Math.random()*1000))
             }
         }
     }


### PR DESCRIPTION
@PaulBlanche I realized that numbers are encoded with a huge amount of precision.
2 is encoded as `FE500M2.00000000000000000000` ... that seems unnecessary to me?

I removed that, and noticed it failed  on the close random number tests

so I tried just appending a number that we know is higher than 9, but only on negative numbers.  This seems to work, tests pass.
` cw.encode(-1)+'a' > cw.encode(-1.00000001)+'a'`